### PR TITLE
Added support for numbered lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install -g md-index-generator
 $ md-index-generator COMMAND
 running command...
 $ md-index-generator (-v|--version|version)
-md-index-generator/0.5.0 darwin-x64 node-v14.3.0
+md-index-generator/0.8.0 darwin-x64 node-v14.5.0
 
 // Display the output on the shell
 $ md-index-generator <MarkDown.md>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "md-index-generator",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -765,9 +765,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.22.tgz",
-      "integrity": "sha512-emeGcJvdiZ4Z3ohbmw93E/64jRzUHAItSHt8nF7M4TGgQTiWqFVGB8KNpLGFmUHmHLvjvBgFwVlqNcq+VuGv9g==",
+      "version": "14.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
+      "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
       "dev": true
     },
     "@types/sinon": {
@@ -4337,9 +4337,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "md-index-generator",
   "description": "Parses a markdown document and creates an index based on headings",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "Alessio Michelini",
   "bin": {
     "md-index-generator": "./bin/run"
@@ -18,7 +18,7 @@
     "@oclif/test": "^1.2.6",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.0",
-    "@types/node": "^14.0.22",
+    "@types/node": "^14.0.23",
     "auto-changelog": "^2.2.0",
     "chai": "^4.2.0",
     "eslint": "^7.4.0",
@@ -27,7 +27,7 @@
     "mocha": "^8.0.1",
     "nyc": "^15.1.0",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.6"
+    "typescript": "^3.9.7"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/src/classes/markdown.ts
+++ b/src/classes/markdown.ts
@@ -70,6 +70,20 @@ export default class MarkdownParser {
   }
 
   /**
+   * Parse a text and try to find if it's a numbered list item or not
+   * @param {string} text The heading to parse
+   * @returns {string} The style according to the type
+   */
+  getListStyle(text: string): string {
+    const regex = /^(\d.\s)/
+    const match = text.match(regex)
+    if (match) {
+      return match[1]
+    }
+    return '- '
+  }
+
+  /**
    * Will parse the headings and return the links format with indentation in base of the heading
    * @param {string[]} links The list of headings to parse
    * @returns {string[]} The list of links
@@ -82,7 +96,8 @@ export default class MarkdownParser {
       }
       const hashes = (heading.match(/#/g) || []).length
       const indents = hashes <= 2 ? 0 : hashes - 2
-      const link = `${'  '.repeat(indents)}- [${textHeading}](#${stringToPermalink(textHeading)})`
+      const listStyle = this.getListStyle(textHeading)
+      const link = `${'  '.repeat(indents)}${listStyle}[${textHeading.replace(listStyle, '')}](#${stringToPermalink(textHeading)})`
       return link
     })
     .filter(heading => heading !== '')

--- a/test/__mocks__/numbered.md
+++ b/test/__mocks__/numbered.md
@@ -1,0 +1,19 @@
+## Numbered list
+
+Some text
+
+### 1. The first
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac blandit dolor, vitae malesuada risus. Suspendisse pharetra in risus sed condimentum. Suspendisse pharetra, leo eu faucibus volutpat, lorem leo bibendum lectus, at lobortis mauris ante non massa. Nulla facilisis ante eget enim lobortis semper. Maecenas efficitur vehicula volutpat. Maecenas hendrerit tincidunt risus, id convallis est aliquam vitae. Aliquam molestie placerat ipsum tincidunt tempus. Aenean tincidunt placerat tempus.
+
+Donec eu ipsum tempor, rhoncus metus eget, lacinia neque. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec mattis augue vel mauris aliquet, sed vehicula purus imperdiet. Praesent at quam ut nunc egestas lacinia tristique at turpis. Nullam luctus mollis ante at ornare. Ut laoreet dui mauris, sed euismod arcu porttitor a. Morbi luctus rhoncus quam sed congue. Nulla eget dolor mauris. Morbi neque justo, imperdiet posuere congue ac, scelerisque pulvinar nisl. Mauris molestie commodo magna, ultrices rutrum nunc malesuada sed.
+
+### 2. The Second
+
+Mauris sollicitudin ipsum id tempus laoreet. Donec blandit placerat quam in lobortis. Integer faucibus rutrum elit. Nunc lacinia eros augue, non mollis erat bibendum eget. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque justo ex, condimentum in suscipit ac, porttitor eget orci. Proin ornare eros eget tincidunt sollicitudin. Quisque consectetur nisi eget neque aliquet, vel pulvinar justo volutpat. Fusce porta condimentum nibh eu pharetra. Integer accumsan dui eleifend orci consectetur consequat.
+
+Fusce elementum rhoncus ante gravida viverra. Aenean aliquet justo id nunc pulvinar, ut hendrerit purus pretium. Nullam consequat blandit nulla non efficitur. Nam porta porttitor arcu vitae semper. Donec placerat, erat a ultrices tempor, ligula ipsum facilisis mi, eu rhoncus tortor justo nec eros. Donec condimentum dui leo. Donec maximus dui neque, eget ornare sem fermentum efficitur. Duis tincidunt luctus mauris vitae sodales. Curabitur porta nisl nec ex aliquet, nec suscipit arcu blandit. Duis eu fringilla magna. Etiam dignissim quam vel turpis porttitor volutpat. Sed scelerisque nisi quis tincidunt gravida.
+
+### 3. The Third
+
+Proin luctus nunc ut commodo porta. Duis vitae arcu feugiat, sollicitudin lorem at, interdum lacus. Mauris lobortis rhoncus lacus et tristique. Vivamus in lectus ac erat laoreet ullamcorper. Mauris ac est odio. Nam consequat velit et tincidunt pretium. Phasellus laoreet fermentum metus, eget consequat justo auctor eu. Nulla facilisi. Duis ut sem in ex fringilla mattis vitae ac orci. Curabitur posuere sodales egestas. Fusce scelerisque consectetur sem a eleifend. Duis a erat eu est eleifend iaculis. Integer placerat, magna et finibus fermentum, felis dolor pellentesque mi, ac mollis odio sapien at arcu. Mauris auctor nisl vitae quam commodo porta.

--- a/test/__mocks__/test.md
+++ b/test/__mocks__/test.md
@@ -13,3 +13,5 @@ Some text here
 ### Sub heading 3
 
 #### Sub sub heading 4
+
+Some random text

--- a/test/classes/markdown.test.ts
+++ b/test/classes/markdown.test.ts
@@ -2,6 +2,7 @@ import {expect} from '@oclif/test'
 import MarkdownParser from '../../src/classes/markdown'
 
 const mockFile = './test/__mocks__/test.md'
+const mockNumberedFile = './test/__mocks__/numbered.md'
 
 describe('MarkdownParser (Class)', () => {
   describe('setTitle', () => {
@@ -58,6 +59,15 @@ describe('MarkdownParser (Class)', () => {
       expect(result.length).to.equal(2)
       expect(result[0]).to.equal('- [Heading 1](#heading-1)')
       expect(result[1]).to.equal('  - [Heading 2](#heading-2)')
+    })
+
+    it('should parse numbered heaedings', () => {
+      const parser = new MarkdownParser(mockNumberedFile)
+      const mockHeadings = ['## Index', '## 1. Heading 1', '## 2. Heading 2']
+      const result = parser.parseHeadings(mockHeadings)
+      expect(result.length).to.equal(2)
+      expect(result[0]).to.equal('1. [Heading 1](#1-heading-1)')
+      expect(result[1]).to.equal('2. [Heading 2](#2-heading-2)')
     })
   })
 


### PR DESCRIPTION
This will recognize the following pattern:

```markdown
## Main
### 1. First
Some text
### 2. Second
Some more text
```

And it will return the following:

```markdown
- [Main](#main)
  1. [First](#1-first)
  2. [Second](#2-second)
```