### PR TITLE
Fix issue with spaces in headings and multi-digit numbered lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## [v3.1.1](https://github.com/darkmavis1980/markdown-index-generator/compare/v3.1.0...v3.1.1)
+## [v3.1.2](https://github.com/darkmavis1980/markdown-index-generator/compare/v3.1.1...v3.1.2)
+
+### Merged
+
+- Fix issue with headings containing extra whitespace [`#72`](https://github.com/darkmavis1980/markdown-index-generator/pull/72)
+
+### Commits
+
+- chore: update package dependencies to latest versions [`80f4325`](https://github.com/darkmavis1980/markdown-index-generator/commit/80f4325e2fde9b96964d8357fbe81d2cce24528a)
+- test: enhance unit tests for MarkdownParser to cover numbered list detection and whitespace handling [`68c3eab`](https://github.com/darkmavis1980/markdown-index-generator/commit/68c3eab5c2043aa2c6270dc2e92619a74179a5c9)
+- refactor: streamline whitespace handling in MarkdownParser headings [`682f038`](https://github.com/darkmavis1980/markdown-index-generator/commit/682f0384e8c7d9f0f9e59fd250b99311a0fdafb1)
+- fix: improve whitespace handling in MarkdownParser headings [`a87aea6`](https://github.com/darkmavis1980/markdown-index-generator/commit/a87aea675a868df9458fb2054bb1a6b73989807d)
+
+## [v3.1.1](https://github.com/darkmavis1980/markdown-index-generator/compare/v3.1.0...v3.1.1) - 2025-04-25
 
 ### Merged
 
@@ -12,6 +25,7 @@
 - test: add unit tests for MarkdownParser to validate whitespace handling in headings [`0c7472d`](https://github.com/darkmavis1980/markdown-index-generator/commit/0c7472da7894e46ea7646cf490cc208c7520ab43)
 - chore: add index markers and update heading formatting in test markdown file [`0d44b9c`](https://github.com/darkmavis1980/markdown-index-generator/commit/0d44b9c0f4c76b40030f8edf572d88a30608e7f9)
 - test: add unit tests for stringToPermalink to handle multiple whitespaces, tabs, and newlines [`611e97e`](https://github.com/darkmavis1980/markdown-index-generator/commit/611e97e3778dfc6866c0244c8cb322c3f3ae32b5)
+- chore: add build step to CI workflows for main and PR processes [`524289d`](https://github.com/darkmavis1980/markdown-index-generator/commit/524289d9a84a6fd29bb57b7abb8e7d6f4d6a2979)
 - style: format whitespace handling in stringToPermalink function for consistency [`62b2915`](https://github.com/darkmavis1980/markdown-index-generator/commit/62b29159c495c71f134681b7c668ca701ed3de8b)
 - fix: replace multiple whitespaces with a single space in stringToPermalink function [`b9e88c5`](https://github.com/darkmavis1980/markdown-index-generator/commit/b9e88c5ca71af91e9307a87a6cb36f63c3f21d65)
 - fix: trim whitespace in stringToPermalink function for cleaner output [`9ab1cfe`](https://github.com/darkmavis1980/markdown-index-generator/commit/9ab1cfee056d371912979b78254a049d0b90c719)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "commander": "^13.1.0",
         "tslib": "^2.8.1",
-        "tsx": "^4.19.3"
+        "tsx": "^4.19.4"
       },
       "bin": {
         "md-index-generator": "bin/run"
@@ -21,7 +21,7 @@
         "@eslint/js": "^9.23.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/jest": "^29.5.14",
-        "@types/node": "^22.15.2",
+        "@types/node": "^22.15.3",
         "@typescript-eslint/parser": "^8.28.0",
         "auto-changelog": "^2.5.0",
         "eslint": "^9.25.1",
@@ -33,7 +33,7 @@
         "ts-jest": "^29.3.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.31.0"
+        "typescript-eslint": "^8.31.1"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -3182,9 +3182,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
-      "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3216,17 +3216,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.0.tgz",
-      "integrity": "sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz",
+      "integrity": "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/type-utils": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/scope-manager": "8.31.1",
+        "@typescript-eslint/type-utils": "8.31.1",
+        "@typescript-eslint/utils": "8.31.1",
+        "@typescript-eslint/visitor-keys": "8.31.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3246,16 +3246,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.0.tgz",
-      "integrity": "sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.1.tgz",
+      "integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/typescript-estree": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/scope-manager": "8.31.1",
+        "@typescript-eslint/types": "8.31.1",
+        "@typescript-eslint/typescript-estree": "8.31.1",
+        "@typescript-eslint/visitor-keys": "8.31.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3271,14 +3271,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.0.tgz",
-      "integrity": "sha512-knO8UyF78Nt8O/B64i7TlGXod69ko7z6vJD9uhSlm0qkAbGeRUSudcm0+K/4CrRjrpiHfBCjMWlc08Vav1xwcw==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.1.tgz",
+      "integrity": "sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0"
+        "@typescript-eslint/types": "8.31.1",
+        "@typescript-eslint/visitor-keys": "8.31.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3289,14 +3289,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.0.tgz",
-      "integrity": "sha512-DJ1N1GdjI7IS7uRlzJuEDCgDQix3ZVYVtgeWEyhyn4iaoitpMBX6Ndd488mXSx0xah/cONAkEaYyylDyAeHMHg==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.1.tgz",
+      "integrity": "sha512-fNaT/m9n0+dpSp8G/iOQ05GoHYXbxw81x+yvr7TArTuZuCA6VVKbqWYVZrV5dVagpDTtj/O8k5HBEE/p/HM5LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0",
+        "@typescript-eslint/typescript-estree": "8.31.1",
+        "@typescript-eslint/utils": "8.31.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.1"
       },
@@ -3313,9 +3313,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.0.tgz",
-      "integrity": "sha512-Ch8oSjVyYyJxPQk8pMiP2FFGYatqXQfQIaMp+TpuuLlDachRWpUAeEu1u9B/v/8LToehUIWyiKcA/w5hUFRKuQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.1.tgz",
+      "integrity": "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3327,14 +3327,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.0.tgz",
-      "integrity": "sha512-xLmgn4Yl46xi6aDSZ9KkyfhhtnYI15/CvHbpOy/eR5NWhK/BK8wc709KKwhAR0m4ZKRP7h07bm4BWUYOCuRpQQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.1.tgz",
+      "integrity": "sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/types": "8.31.1",
+        "@typescript-eslint/visitor-keys": "8.31.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3367,16 +3367,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.0.tgz",
-      "integrity": "sha512-qi6uPLt9cjTFxAb1zGNgTob4x9ur7xC6mHQJ8GwEzGMGE9tYniublmJaowOJ9V2jUzxrltTPfdG2nKlWsq0+Ww==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.1.tgz",
+      "integrity": "sha512-2DSI4SNfF5T4oRveQ4nUrSjUqjMND0nLq9rEkz0gfGr3tg0S5KB6DhwR+WZPCjzkZl3cH+4x2ce3EsL50FubjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/typescript-estree": "8.31.0"
+        "@typescript-eslint/scope-manager": "8.31.1",
+        "@typescript-eslint/types": "8.31.1",
+        "@typescript-eslint/typescript-estree": "8.31.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3391,13 +3391,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.0.tgz",
-      "integrity": "sha512-QcGHmlRHWOl93o64ZUMNewCdwKGU6WItOU52H0djgNmn1EOrhVudrDzXz4OycCRSCPwFCDrE2iIt5vmuUdHxuQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.1.tgz",
+      "integrity": "sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
+        "@typescript-eslint/types": "8.31.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -4129,9 +4129,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001715",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
-      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
+      "version": "1.0.30001716",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz",
+      "integrity": "sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==",
       "dev": true,
       "funding": [
         {
@@ -4293,9 +4293,9 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.41.0.tgz",
-      "integrity": "sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==",
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
+      "integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4591,9 +4591,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.142",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.142.tgz",
-      "integrity": "sha512-Ah2HgkTu/9RhTDNThBtzu2Wirdy4DC9b0sMT1pUhbkZQ5U/iwmE+PHZX1MpjD5IkJCc2wSghgGG/B04szAx07w==",
+      "version": "1.5.145",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.145.tgz",
+      "integrity": "sha512-pZ5EcTWRq/055MvSBgoFEyKf2i4apwfoqJbK/ak2jnFq8oHjZ+vzc3AhRcz37Xn+ZJfL58R666FLJx0YOK9yTw==",
       "dev": true,
       "license": "ISC"
     },
@@ -9339,9 +9339,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/type-fest": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
-      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.1.tgz",
+      "integrity": "sha512-9YvLNnORDpI+vghLU/Nf+zSv0kL47KbVJ1o3sKgoTefl6i+zebxbiDQWoe/oWWqPhIgQdRZRT1KA9sCPL810SA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -9438,9 +9438,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
-      "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
+      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.25.0",
@@ -9595,15 +9595,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.0.tgz",
-      "integrity": "sha512-u+93F0sB0An8WEAPtwxVhFby573E8ckdjwUUQUj9QA4v8JAvgtoDdIyYR3XFwFHq2W1KJ1AurwJCO+w+Y1ixyQ==",
+      "version": "8.31.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.1.tgz",
+      "integrity": "sha512-j6DsEotD/fH39qKzXTQRwYYWlt7D+0HmfpOK+DVhwJOFLcdmn92hq3mBb7HlKJHbjjI/gTOqEcc9d6JfpFf/VA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.31.0",
-        "@typescript-eslint/parser": "8.31.0",
-        "@typescript-eslint/utils": "8.31.0"
+        "@typescript-eslint/eslint-plugin": "8.31.1",
+        "@typescript-eslint/parser": "8.31.1",
+        "@typescript-eslint/utils": "8.31.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "md-index-generator",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "md-index-generator",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   "dependencies": {
     "commander": "^13.1.0",
     "tslib": "^2.8.1",
-    "tsx": "^4.19.3"
+    "tsx": "^4.19.4"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.9",
     "@eslint/js": "^9.23.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.15.2",
+    "@types/node": "^22.15.3",
     "@typescript-eslint/parser": "^8.28.0",
     "auto-changelog": "^2.5.0",
     "eslint": "^9.25.1",
@@ -30,7 +30,7 @@
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.31.0"
+    "typescript-eslint": "^8.31.1"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "md-index-generator",
   "description": "Parses a markdown document and creates an index based on headings",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "author": "Alessio Michelini",
   "type": "module",
   "bin": {

--- a/src/classes/markdown.ts
+++ b/src/classes/markdown.ts
@@ -92,9 +92,7 @@ export class MarkdownParser {
     const currentTitle = this.title.replace(/##\s/gim, '').toLocaleLowerCase().trim();
     return links
       .map(heading => {
-        const textHeading: string = heading
-          .replace(/\s+/g, ' ')
-          .replace(/#{2,5}\s/, '');
+        const textHeading: string = heading.replace(/\s+/g, ' ').replace(/#{2,5}\s/, '');
         if (textHeading.toLocaleLowerCase() === 'index' || textHeading.toLocaleLowerCase() === currentTitle) {
           return '';
         }

--- a/src/classes/markdown.ts
+++ b/src/classes/markdown.ts
@@ -74,7 +74,7 @@ export class MarkdownParser {
    * @returns The style according to the type
    */
   getListStyle(text: string): string {
-    const regex = /^(\d.\s)/;
+    const regex = /^(\d+\.\s)/;
     const match = text.match(regex);
     if (match) {
       return match[1];

--- a/src/classes/markdown.ts
+++ b/src/classes/markdown.ts
@@ -92,7 +92,9 @@ export class MarkdownParser {
     const currentTitle = this.title.replace(/##\s/gim, '').toLocaleLowerCase().trim();
     return links
       .map(heading => {
-        const textHeading: string = heading.replace(/#{2,5}\s/, '');
+        const textHeading: string = heading
+          .replace(/\s+/g, ' ')
+          .replace(/#{2,5}\s/, '');
         if (textHeading.toLocaleLowerCase() === 'index' || textHeading.toLocaleLowerCase() === currentTitle) {
           return '';
         }


### PR DESCRIPTION
## Summary
This PR addresses two key issues in the Markdown Index Generator:
- Improves whitespace handling in headings to ensure proper normalization
- Fixes a bug in the numbered list detection that failed to recognize multi-digit numbers (e.g., "10.")

## Changes
- Updated the regex pattern in `getListStyle` method to use `\d+` instead of `\d` to match multiple digits
- Enhanced whitespace handling in `parseHeadings` by adding proper normalization with `replace(/\s+/g, ' ')`
- Added comprehensive unit tests for:
  - Headings with excessive whitespace
  - Multi-digit numbered list detection
  - Whitespace normalization
  - Custom title filtering

## Testing
All tests are passing, including the new tests specifically created to verify these fixes.

## Related Issue
Closes #70 